### PR TITLE
Fix: Userテーブルのnameカラムにunique制約を追加 #2

### DIFF
--- a/db/migrate/20220204092827_create_users.rb
+++ b/db/migrate/20220204092827_create_users.rb
@@ -1,7 +1,7 @@
 class CreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|
-      t.string :name, null: false
+      t.string :name, null: false, unique: true
 
       t.timestamps
     end


### PR DESCRIPTION
#### 変更点
・Userテーブルの`name`カラムに`unique`制約を追加
##### 理由
DB格納時の`each`処理で、同じユーザーの重複レコードを作成しないようにするため
（`User.create`ではなく、`User.find_or_create_by`で実行）