### PR TITLE
Fix: Itemテーブルのurlカラムをtext型に変更 #2

### DIFF
--- a/db/migrate/20220204093414_create_items.rb
+++ b/db/migrate/20220204093414_create_items.rb
@@ -2,7 +2,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
   def change
     create_table :items do |t|
       t.string :title, null: false
-      t.string :url, null: false, unique: true
+      t.text :url, null: false, unique: true
       t.integer :likes_count, null: false
       t.references :user, foreign_key: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,7 @@ ActiveRecord::Schema.define(version: 2022_02_04_123030) do
 
   create_table "items", force: :cascade do |t|
     t.string "title", null: false
-    t.string "url", null: false
+    t.text "url", null: false
     t.integer "likes_count", null: false
     t.integer "user_id"
     t.datetime "created_at", null: false


### PR DESCRIPTION
refs #2 
#### 変更点
・URL格納時に文字数不足のため、Itemテーブルの`url`カラムを`string`から`text`型に変更