### PR TITLE
Qiitaの記事データをAPIで取得し、DBに保存するバッチを作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem "bootstrap_form", '~> 5.0'
 
 gem 'dotenv-rails'
 
+gem 'whenever', require: false
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem 'bootstrap', '~> 5.1.0'
 gem 'popper_js', '~> 2.9.3'
 gem "bootstrap_form", '~> 5.0'
 
+gem 'dotenv-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     execjs (2.8.1)
     ffi (1.15.5)
@@ -220,6 +224,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  dotenv-rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   popper_js (~> 2.9.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    chronic (0.10.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -210,6 +211,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -239,6 +242,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  whenever
 
 RUBY VERSION
    ruby 2.6.6p146

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ Bundler.require(*Rails.groups)
 module QiitaApp
   class Application < Rails::Application
     config.load_defaults 5.2
+    config.time_zone = 'Tokyo'
     config.generators do |g|
       g.assets false
       g.helper false

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,8 @@
+require File.expand_path(File.dirname(__FILE__) + "/environment")
+rails_env = ENV['RAILS_ENV'] || :development
+set :environment, rails_env
+set :output, "#{Rails.root}/log/cron.log"
+
+every 1.day, at: '9:00' do
+  rake 'db:reset'
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,28 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+access_token = ENV['QIITA_TOKEN']
+all_articles = []
+resource_url = 'https://qiita.com/api/v2/items'
+headers = { 'Authorization' => "Bearer #{access_token}" }
+page = 0
+10.times do
+  page += 1
+  params = {
+    'page' => page,
+    'per_page' => '100'
+  }
+  url = resource_url + '?' + URI.encode_www_form(params)
+  res = URI.open(url, headers)
+  articles = JSON.parse(res.read)
+  break if articles.empty?
+  all_articles.concat articles
+end
+all_articles.sort_by!{ |hash| hash['likes_count'].to_i }.reverse!
+
+all_articles.each do |article|
+  user = User.find_or_create_by!(name: article['user']['id'])
+  item = user.items.create!(title: article['title'], url: article['url'], likes_count: article['likes_count'], created_at: article['created_at'])
+  if article['tags'].size > 0
+    article['tags'].each do |tag|
+      item.tags.create!(name: tag['name'])
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,3 +26,4 @@ all_articles.each do |article|
     end
   end
 end
+p "#{Time.current}: DB更新処理が完了しました"


### PR DESCRIPTION
refs #8 
#### メイン処理
・[Qiita API v2](https://qiita.com/api/v2/docs#%E6%8A%95%E7%A8%BF)を使用し、記事データを取得
・`gem 'dotenv-rails'`を使用し、`.env`にQiitaの環境変数を設定 cf839f7
・`seeds.rb`で1000件の記事データ取得・DB保存処理を行う 3ab1cbc
・`cron`で毎朝9時に`rake db:reset`を実行し、DBを更新する 1860c01 b251c2f

##### その他の変更
・ログでバッチ実行時刻の確認をスムーズにするため、標準時間を日本時間に変更 5800d33