### PR TITLE
Qiitaの人気記事一覧が確認できる画面を作成する #1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem 'whenever', require: false
 
 gem 'kaminari'
 
+gem 'font-awesome-sass'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'dotenv-rails'
 
 gem 'whenever', require: false
 
+gem 'kaminari'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,8 @@ GEM
     erubi (1.10.0)
     execjs (2.8.1)
     ffi (1.15.5)
+    font-awesome-sass (5.15.1)
+      sassc (>= 1.11)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.9.1)
@@ -240,6 +242,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   dotenv-rails
+  font-awesome-sass
   jbuilder (~> 2.5)
   kaminari
   listen (>= 3.0.5, < 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,18 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -229,6 +241,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   dotenv-rails
   jbuilder (~> 2.5)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   popper_js (~> 2.9.3)
   puma (~> 3.11)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,6 @@
 @import "bootstrap";
 @import "rails_bootstrap_forms";
+
+.pagination {
+  justify-content: center;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,17 @@
 @import "bootstrap";
 @import "rails_bootstrap_forms";
+@import "font-awesome-sprockets";
+@import "font-awesome";
+
+body {
+  background-color: #f6f6f4;
+}
+
+.container {
+  background-color: white;
+  padding: 30px;
+  width: 80%;
+}
 
 .pagination {
   justify-content: center;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
   def index
+    @items = Item.page(params[:page]).per(20)
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -3,7 +3,20 @@
 <br>
 <div>
   <% @items.each do |item| %>
-    <p><%= link_to item.title, item.url, target: :_blank, rel: "noopener noreferrer" %></p>
+    <div>
+      <%= link_to "@#{item.user.name}", "https://qiita.com/#{item.user.name}", target: :_blank, rel: "noopener noreferrer" %>が<%= item.created_at.strftime("%Y年%m月%d日") %>に投稿
+    </div>
+    <h5><%= link_to item.title, item.url, target: :_blank, rel: "noopener noreferrer" %></h5>
+    <p>
+      タグ: 
+      <% item.tags.each do |tag| %>
+        <%= link_to "https://qiita.com/tags/#{tag.name}", target: :_blank, rel: "noopener noreferrer" do %>
+          <%= "#{tag.name}"%>
+        <% end %>
+      <% end %>
+      　
+      LGTM: <%= item.likes_count %>
+    </p>
   <% end %>
 </div>
 <br>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,2 +1,10 @@
-<h1>Items#index</h1>
-<p>Find me in app/views/items/index.html.erb</p>
+<br>
+<h2>Qiita人気記事一覧</h2>
+<br>
+<div>
+  <% @items.each do |item| %>
+    <p><%= link_to item.title, item.url, target: :_blank, rel: "noopener noreferrer" %></p>
+  <% end %>
+</div>
+<br>
+<%= paginate @items %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -4,14 +4,14 @@
 <div>
   <% @items.each do |item| %>
     <div>
-      <%= link_to "@#{item.user.name}", "https://qiita.com/#{item.user.name}", target: :_blank, rel: "noopener noreferrer" %>が<%= item.created_at.strftime("%Y年%m月%d日") %>に投稿
+      <%= link_to "@#{item.user.name}", "https://qiita.com/#{item.user.name}", target: :_blank, rel: "noopener noreferrer", style: "color:gray;" %>が<%= item.created_at.strftime("%Y年%m月%d日") %>に投稿
     </div>
     <h5><%= link_to item.title, item.url, target: :_blank, rel: "noopener noreferrer" %></h5>
     <p>
       タグ: 
       <% item.tags.each do |tag| %>
-        <%= link_to "https://qiita.com/tags/#{tag.name}", target: :_blank, rel: "noopener noreferrer" do %>
-          <%= "#{tag.name}"%>
+        <%= link_to "https://qiita.com/tags/#{tag.name}", target: :_blank, rel: "noopener noreferrer", style: "color:gray; font-size:0.9rem;" do %>
+          <i class="fas fa-tags"></i><%= "#{tag.name}"%>
         <% end %>
       <% end %>
       　

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,8 @@
   </head>
 
   <body>
-    <%= yield %>
+    <div class="container">
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ module QiitaApp
   class Application < Rails::Application
     config.load_defaults 5.2
     config.time_zone = 'Tokyo'
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     config.generators do |g|
       g.assets false
       g.helper false

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,17 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: ""
+          one: "<strong>1-1</strong>/1件中"
+          other: "<strong>1-%{count}</strong>/%{count}件中"
+      more_pages:
+        display_entries: "<strong>%{first}-%{last}</strong>/%{total}件中"


### PR DESCRIPTION
refs #1 
#### 変更点
1. 下記5項目を記事一覧ページに表示する 53e83db
- [x] 記事タイトル（クリックすると別タブで記事元サイトに飛ぶ）
- [x] リアクション数
- [x] 投稿者名
- [x] 作成日時
- [x] タグ
2. `gem 'kaminari'`でページネーションを追加 e97ceaf

##### その他の変更
・タグ横に`font-awsome`アイコンを追加 d000a7f
・`background-color`をQiita公式と同じ色に設定 8908a18